### PR TITLE
docker-compose: Fix dapr components dir when using merged compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       "--resources-path", "./components"
     ]
     volumes:
-      - "./components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
+      - "./../course_service/components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
     depends_on:
       - app-course
       - redis


### PR DESCRIPTION
Quick fix to docker-compose file because docker does not resolve paths correctly when using its function to merge multiple docker-compose files