### PR TITLE
Add more mutations & fields for course memberships

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/course_service/controller/MembershipController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/course_service/controller/MembershipController.java
@@ -3,8 +3,10 @@ package de.unistuttgart.iste.gits.course_service.controller;
 import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 import de.unistuttgart.iste.gits.common.user_handling.UserCourseAccessValidator;
 import de.unistuttgart.iste.gits.course_service.service.MembershipService;
+import de.unistuttgart.iste.gits.generated.dto.Course;
 import de.unistuttgart.iste.gits.generated.dto.CourseMembership;
 import de.unistuttgart.iste.gits.generated.dto.CourseMembershipInput;
+import de.unistuttgart.iste.gits.generated.dto.UserRoleInCourse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -26,6 +28,16 @@ public class MembershipController {
     @QueryMapping(name = "_internal_noauth_courseMembershipsByUserIds")
     public List<List<CourseMembership>> courseMembershipsByUserIds(@Argument final List<UUID> userIds) {
         return membershipService.getAllMembershipsByUserIds(userIds);
+    }
+
+    @MutationMapping
+    public CourseMembership joinCourse(@Argument final UUID courseId,
+                             @ContextValue final LoggedInUser currentUser) {
+        return membershipService.createMembership(CourseMembershipInput.builder()
+                .setCourseId(courseId)
+                .setUserId(currentUser.getId())
+                .setRole(UserRoleInCourse.STUDENT)
+                .build());
     }
 
     @MutationMapping

--- a/src/main/java/de/unistuttgart/iste/gits/course_service/controller/MembershipController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/course_service/controller/MembershipController.java
@@ -9,10 +9,7 @@ import de.unistuttgart.iste.gits.generated.dto.CourseMembershipInput;
 import de.unistuttgart.iste.gits.generated.dto.UserRoleInCourse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.ContextValue;
-import org.springframework.graphql.data.method.annotation.MutationMapping;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
@@ -68,5 +65,15 @@ public class MembershipController {
                 inputDto.getCourseId());
 
         return membershipService.deleteMembership(inputDto);
+    }
+
+    @SchemaMapping(typeName = "Course", field = "memberships")
+    public List<CourseMembership> memberships(final Course course,
+                                              @ContextValue final LoggedInUser currentUser) {
+        UserCourseAccessValidator.validateUserHasAccessToCourse(currentUser,
+                LoggedInUser.UserRoleInCourse.ADMINISTRATOR,
+                course.getId());
+
+        return membershipService.getMembershipsOfCourse(course.getId());
     }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/course_service/persistence/repository/CourseMembershipRepository.java
+++ b/src/main/java/de/unistuttgart/iste/gits/course_service/persistence/repository/CourseMembershipRepository.java
@@ -16,18 +16,19 @@ import java.util.UUID;
 public interface CourseMembershipRepository extends JpaRepository<CourseMembershipEntity, CourseMembershipPk> {
 
     /**
-     * Find Courses by CourseID
+     * Finds all course memberships for the specified users. Returns a list of CourseMembershipEntities for the given
+     * user ids in no particular order.
      *
-     * @param userIds of the courses to find
-     * @return List of CourseMembershipEntities
+     * @param userIds IDs of the users to find their courses for.
+     * @return List of CourseMembershipEntities for the users with the given ids.
      */
     List<CourseMembershipEntity> findByUserIdIn(List<UUID> userIds);
 
     /**
-     * Hibernate Query. Find Entities by Course ID. ORDERED BY User ID
+     * Finds all course memberships of the course with the specified id.
      *
-     * @param courseId Course ID
-     * @return List of Entities
+     * @param courseId ID of the course to find the memberships for.
+     * @return List of CourseMembershipEntities for the course with the given id.
      */
     List<CourseMembershipEntity> findCourseMembershipEntitiesByCourseId(UUID courseId);
 }

--- a/src/main/java/de/unistuttgart/iste/gits/course_service/service/MembershipService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/course_service/service/MembershipService.java
@@ -101,6 +101,13 @@ public class MembershipService {
         }
     }
 
+    public List<CourseMembership> getMembershipsOfCourse(final UUID courseId) {
+        return courseMembershipRepository.findCourseMembershipEntitiesByCourseId(courseId)
+                .stream()
+                .map(membershipMapper::entityToDto)
+                .toList();
+    }
+
 
     /**
      * Helper function to validate existence of an entity in the database

--- a/src/main/resources/graphql/service/course.graphqls
+++ b/src/main/resources/graphql/service/course.graphqls
@@ -54,6 +54,12 @@ type Course {
         """
         sortDirection: [SortDirection!]! = [ASC],
         pagination: Pagination): ChapterPayload!
+    """
+    Course Memberships of this course. Contains information about which users are members of the course and what
+    role they have in it.
+    🔒 User needs to be at least an admin of the course to access this field.
+    """
+    memberships: [CourseMembership!]!
 }
 
 """

--- a/src/main/resources/graphql/service/mutation.graphqls
+++ b/src/main/resources/graphql/service/mutation.graphqls
@@ -38,6 +38,11 @@ type Mutation {
     deleteChapter(id: UUID!): UUID!
 
     """
+    Lets the current user join a course as a student.
+    """
+    joinCourse(courseId: UUID!): CourseMembership!
+
+    """
     Adds the specified user to the specified course with the specified role.
     🔒 The calling user must be an admin in this course to perform this action.
     """

--- a/src/main/resources/graphql/service/query.graphqls
+++ b/src/main/resources/graphql/service/query.graphqls
@@ -41,7 +41,7 @@ type Query {
     resourceById(ids: [UUID!]!): [CourseResourceAssociation!]! @deprecated(reason: "Use courseResourceAssociationsByIds instead.")
 
     """
-    Returns the list of courseMemberships for the specified User.
+    Returns the list of courseMemberships for the specified users.
     ⚠️ This query is only accessible internally in the system and allows the caller to retrieve courseMemberships for
     any user and should not be called without any validation of the caller's permissions. ⚠️
     """

--- a/src/test/java/de/unistuttgart/iste/gits/course_service/integration/MutationJoinCourseTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/course_service/integration/MutationJoinCourseTest.java
@@ -1,0 +1,73 @@
+package de.unistuttgart.iste.gits.course_service.integration;
+
+import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
+import de.unistuttgart.iste.gits.common.testutil.InjectCurrentUserHeader;
+import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
+import de.unistuttgart.iste.gits.course_service.persistence.entity.CourseEntity;
+import de.unistuttgart.iste.gits.course_service.persistence.entity.CourseMembershipEntity;
+import de.unistuttgart.iste.gits.course_service.persistence.entity.CourseMembershipPk;
+import de.unistuttgart.iste.gits.course_service.persistence.repository.CourseMembershipRepository;
+import de.unistuttgart.iste.gits.course_service.persistence.repository.CourseRepository;
+import de.unistuttgart.iste.gits.generated.dto.UserRoleInCourse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.test.tester.HttpGraphQlTester;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.*;
+
+@GraphQlApiTest
+class MutationJoinCourseTest {
+
+    @Autowired
+    private CourseRepository courseRepository;
+    @Autowired
+    private CourseMembershipRepository courseMembershipRepository;
+
+    @InjectCurrentUserHeader
+    private final UUID currentUserId = UUID.randomUUID();
+
+    @Test
+    void testJoinCourse(final HttpGraphQlTester tester) {
+        final CourseEntity course = courseRepository.save(CourseEntity.builder().title("Course 1")
+                .description("This is course 1")
+                .startDate(OffsetDateTime.parse("2020-01-01T00:00:00.000Z"))
+                .endDate(OffsetDateTime.parse("2021-01-01T00:00:00.000Z"))
+                .published(true)
+                .build());
+
+        final String query =
+                """
+                mutation($courseId: UUID!) {
+                    joinCourse(courseId: $courseId) {
+                        userId
+                        courseId
+                        role
+                        course {
+                            description
+                        }
+                    }
+                }
+                """;
+
+        tester.document(query)
+                .variable("courseId", course.getId())
+                .execute()
+                .path("joinCourse.userId").entity(UUID.class).isEqualTo(currentUserId)
+                .path("joinCourse.courseId").entity(UUID.class).isEqualTo(course.getId())
+                .path("joinCourse.role").entity(UserRoleInCourse.class).isEqualTo(UserRoleInCourse.STUDENT)
+                .path("joinCourse.course.description").entity(String.class).isEqualTo("This is course 1");
+
+        final CourseMembershipEntity membership = assertDoesNotThrow(() ->
+                courseMembershipRepository
+                        .findById(new CourseMembershipPk(currentUserId, course.getId()))
+                        .orElseThrow());
+
+        assertThat(membership.getUserId()).isEqualTo(currentUserId);
+        assertThat(membership.getCourseId()).isEqualTo(course.getId());
+        assertThat(membership.getRole()).isEqualTo(UserRoleInCourse.STUDENT);
+    }
+}


### PR DESCRIPTION
## Description of changes
* Add mutation `joinCourse(userId: UUID!)` to join a course as a student
* In `Course` type: Add `memberships: [CourseMembership!]!` field which an admin can use to get all members of the course

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [x] automated integration test
- [ ] manual, exploratory test
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
